### PR TITLE
upgrade python to version 3.9, because 3.6 is not supported anymore

### DIFF
--- a/templates/generateid.template.yaml
+++ b/templates/generateid.template.yaml
@@ -52,7 +52,7 @@ Resources:
               - "       send(event, context, 'SUCCESS', responseData)"
               - '       return token'
       Handler: index.handler
-      Runtime: python3.6
+      Runtime: python3.9
       Timeout: 5
       Role:
         Fn::GetAtt:


### PR DESCRIPTION
*Issue #, if available:*
Python 3.6 is deprecated by the Lambda environment which hinders the stack to deploy.

*Description of changes:*
upgrade python to version 3.9

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
